### PR TITLE
change to a more standard way of looking up the python interpreter

### DIFF
--- a/dmscan.py
+++ b/dmscan.py
@@ -1,4 +1,4 @@
-#!/usr/local/bin/python3
+#!/usr/bin/env python3
 import logging
 import argparse
 import sys


### PR DESCRIPTION
this will work regardless of whether python3 is in /usr/local/bin or
/usr/bin or somewhere completely different